### PR TITLE
Add Market Cap API documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -203,33 +203,6 @@ components:
         volume:
           description: The calculated volume in the last 24 hours.
           type: string
-    GlobalWeightedAverage:
-      type: object
-      properties:
-        id:
-          description: Unique identifier for the resource.
-          type: string
-          format: uuid
-        assetId:
-          description: The asset id of the global weighted average.
-          type: string
-          format: string
-        timestamp:
-          description: The timestamp the global weighted average was calculated.
-          type: string
-          format: date-time
-        price:
-          description: The global weighted average price of the asset in USD.
-          type: string
-        volume:
-          description: The total global weighted average 24h volume of the asset.
-          type: string
-        totalSupply:
-          description: The total supply of the asset.
-          type: string
-        freeFloatSupply:
-          description: The circulating supply of the asset.
-          type: string
     OpenHighLowCloseVolume:
       type: object
       properties:
@@ -276,6 +249,57 @@ components:
         twap:
           description: The 24h time-weighted average price of the index
           type: string
+    MarketCap:
+      type: object
+      properties:
+        id:
+          description: Unique identifier for the resource.
+          type: string
+          format: uuid
+        assetId:
+          description: The asset id
+          type: string
+          format: uuid
+        timestamp:
+          description: The timestamp the market capitalisation was calculated.
+          type: string
+          format: date-time
+        marketCapRank:
+          description: The market cap ranking order.
+          type: string
+        volumeRank:
+          description: The 24hr volume ranking order.
+          type: string
+        price:
+          description: The global weighted average price of the asset in USD.
+          type: string
+        volume:
+          description: The total global weighted average 24h volume of the asset.
+          type: string
+        totalSupply:
+          description: The total supply of the asset.
+          type: string
+        freeFloatSupply:
+          description: The circulating supply of the asset.
+          type: string
+        marketCap:
+          description: Market cap in USD based on the price and the free float supply.
+          type: string
+        totalMarketCap:
+          description: USD market cap figure based on total supply.
+          type: string
+        marketCapChange:
+          description: Percentage change in market cap for the requested period.
+          type: string
+        totalMarketCapChange:
+          description: Percentage change in the total market cap for the requested period.
+          type: string
+        volumeChange:
+          description: Percentage change in 24hr volume.
+          type: string
+        priceChange:
+          description: Percentage change in spot price for the requested period.
+          type: string
   parameters:
     idParam:
       name: id
@@ -306,7 +330,7 @@ x-tagGroups:
       - Websocket Errors
       - Websocket Exchange Ticker
       - Websocket Index Ticker - Beta Version
-
+      - Market Cap
   - name: Rest API
     tags:
       - Rest API Errors
@@ -1219,13 +1243,17 @@ paths:
   /marketcap:
     get:
       tags:
-        - Market Capitalisation
+        - Market Cap
       summary: |
         List the market capitalisation for assets
       description: |
-        ** THIS ENDPOINT IS CURRENTLY NOT AVAILABLE **
 
-        This API provides the market cap for the assets based on the GWA. This only provides the latest market cap is provided.
+        This API will return a list of assets ranked by their market capitalization.
+
+        The Market Cap is calculated based on the free float (or circulating) supply figures and the GWA index price. The Total Market Cap is calculated based on the total supply and the GWA index price.
+
+        Period parameter can also be passed to it to returns the movement in percentage of these values over a 24h, 7d or 30d period.
+
       operationId: listMarketCaps
       x-code-samples:
         - lang: Shell
@@ -1242,7 +1270,7 @@ paths:
         - name: period
           in: query
           description: The period in days to look back for percentage movements
-          required: true
+          required: false
           schema:
             type: string
             enum:
@@ -1251,7 +1279,7 @@ paths:
               - 30
       responses:
         '200':
-          description: The market capitalisation of the assets
+          description: 'Market Capitalization by assets'
           content:
             application/json:
               schema:
@@ -1261,26 +1289,7 @@ paths:
                   content:
                     type: array
                     items:
-                      allOf:
-                        - $ref: '#/components/schemas/GlobalWeightedAverage'
-                        - type: object
-                          properties:
-                            marketCap:
-                              description: The market capitalisation in USD
-                              type: string
-                            priceChange:
-                              description: The percentage price change for the given period
-                              type: string
-                            volumeChange:
-                              description: The percentage volume change for the given period
-                              type: string
-                            marketCapChange:
-                              description: The percentage market cap change for the given period
-                              type: string
-                  nextId:
-                    description: The next id which can be used for pagination
-                    type: string
-                    format: uuid
+                      $ref: '#/components/schemas/MarketCap'
   /price:
     get:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -293,7 +293,7 @@ components:
           description: The total supply of the asset.
           type: string
         freeFloatSupply:
-          description: The circulating supply of the asset.
+          description: The circulating supply of the asset. It is the total supply less any supply that has been removed from circulation.
           type: string
         marketCap:
           description: Market cap in USD based on the price and the free float supply.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -330,7 +330,6 @@ x-tagGroups:
       - Websocket Errors
       - Websocket Exchange Ticker
       - Websocket Index Ticker - Beta Version
-      - Market Cap
   - name: Rest API
     tags:
       - Rest API Errors

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -253,13 +253,13 @@ components:
       type: object
       description: The percent change over a period of time.
       properties:
-        24h:
+        change24h:
           description: Percentage change for the 24 hour period.
           type: string
-        7d:
+        change7d:
           description: Percentage change for the 7 day period.
           type: string
-        30d:
+        change30d:
           description: Percentage change for the 30 day period.
           type: string
     MarketCap:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -249,6 +249,46 @@ components:
         twap:
           description: The 24h time-weighted average price of the index
           type: string
+    MarketCapPercentChange:
+      type: object
+      description: The percent change over a period of time.
+      properties:
+        marketCapChange_24h:
+          description: Percentage change in market cap for the 24 hour period.
+          type: string
+        totalMarketCapChange_24h:
+          description: Percentage change in the total market cap for the 24 hour period.
+          type: string
+        volumeChange_24h:
+          description: Percentage change in 24hr volume.
+          type: string
+        priceChange_24h:
+          description: Percentage change in spot price for the 24 hour period.
+          type: string
+        marketCapChange_7d:
+          description: Percentage change in market cap for the 7 day period.
+          type: string
+        totalMarketCapChange_7d:
+          description: Percentage change in the total market cap for the 7 day period.
+          type: string
+        volumeChange_7d:
+          description: Percentage change in 7 day period.
+          type: string
+        priceChange_7d:
+          description: Percentage change in spot price for the 7 day period.
+          type: string
+        marketCapChange_30d:
+          description: Percentage change in market cap for the 30 day period.
+          type: string
+        totalMarketCapChange_30d:
+          description: Percentage change in the total market cap for the 30 day period.
+          type: string
+        volumeChange_30d:
+          description: Percentage change in volume foe the 30 day period.
+          type: string
+        priceChange_30d:
+          description: Percentage change in spot price for the 30 day period.
+          type: string
     MarketCap:
       type: object
       properties:
@@ -288,18 +328,8 @@ components:
         totalMarketCap:
           description: USD market cap figure based on total supply.
           type: string
-        marketCapChange:
-          description: Percentage change in market cap for the requested period.
-          type: string
-        totalMarketCapChange:
-          description: Percentage change in the total market cap for the requested period.
-          type: string
-        volumeChange:
-          description: Percentage change in 24hr volume.
-          type: string
-        priceChange:
-          description: Percentage change in spot price for the requested period.
-          type: string
+        percentChange:
+          $ref: '#/components/schemas/MarketCapPercentChange'
   parameters:
     idParam:
       name: id
@@ -1266,16 +1296,12 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: period
+        - name: returnPercentChange
           in: query
-          description: The period in days to look back for percentage movements
+          description: Return the percent change in the values. Currently we support change over 24hour, 7 Days and 30 Days.
           required: false
           schema:
-            type: string
-            enum:
-              - 1
-              - 7
-              - 30
+            type: boolean
       responses:
         '200':
           description: 'Market Capitalization by assets'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -253,41 +253,14 @@ components:
       type: object
       description: The percent change over a period of time.
       properties:
-        marketCapChange_24h:
-          description: Percentage change in market cap for the 24 hour period.
+        24h:
+          description: Percentage change for the 24 hour period.
           type: string
-        totalMarketCapChange_24h:
-          description: Percentage change in the total market cap for the 24 hour period.
+        7d:
+          description: Percentage change for the 7 day period.
           type: string
-        volumeChange_24h:
-          description: Percentage change in 24hr volume.
-          type: string
-        priceChange_24h:
-          description: Percentage change in spot price for the 24 hour period.
-          type: string
-        marketCapChange_7d:
-          description: Percentage change in market cap for the 7 day period.
-          type: string
-        totalMarketCapChange_7d:
-          description: Percentage change in the total market cap for the 7 day period.
-          type: string
-        volumeChange_7d:
-          description: Percentage change in 7 day period.
-          type: string
-        priceChange_7d:
-          description: Percentage change in spot price for the 7 day period.
-          type: string
-        marketCapChange_30d:
-          description: Percentage change in market cap for the 30 day period.
-          type: string
-        totalMarketCapChange_30d:
-          description: Percentage change in the total market cap for the 30 day period.
-          type: string
-        volumeChange_30d:
-          description: Percentage change in volume foe the 30 day period.
-          type: string
-        priceChange_30d:
-          description: Percentage change in spot price for the 30 day period.
+        30d:
+          description: Percentage change for the 30 day period.
           type: string
     MarketCap:
       type: object
@@ -328,7 +301,13 @@ components:
         totalMarketCap:
           description: USD market cap figure based on total supply.
           type: string
-        percentChange:
+        marketCapChange:
+          $ref: '#/components/schemas/MarketCapPercentChange'
+        totalMarketCapChange:
+          $ref: '#/components/schemas/MarketCapPercentChange'
+        volumeChange:
+          $ref: '#/components/schemas/MarketCapPercentChange'
+        priceChange:
           $ref: '#/components/schemas/MarketCapPercentChange'
   parameters:
     idParam:
@@ -1269,7 +1248,7 @@ paths:
                     description: The next id which can be used for pagination
                     type: string
                     format: uuid
-  /marketcap:
+  /market-cap:
     get:
       tags:
         - Market Cap
@@ -1281,13 +1260,13 @@ paths:
 
         The Market Cap is calculated based on the free float (or circulating) supply figures and the GWA index price. The Total Market Cap is calculated based on the total supply and the GWA index price.
 
-        Period parameter can also be passed to it to returns the movement in percentage of these values over a 24h, 7d or 30d period.
+        If the percentChange parameter is set to true this API will also return movement in percentage of these values over a 24h, 7d or 30d period.
 
       operationId: listMarketCaps
       x-code-samples:
         - lang: Shell
           label: curl
-          source: "curl https://api.bravenewcoin.com/v3/marketcap/?period=1 -H 'Authorization: Bearer test_SiHrnL5NKsea0G2W4LHd' -G"
+          source: "curl https://api.bravenewcoin.com/v3/market-cap -H 'Authorization: Bearer test_SiHrnL5NKsea0G2W4LHd' -G"
       parameters:
         - name: assetId
           in: query
@@ -1296,9 +1275,9 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: returnPercentChange
+        - name: percentChange
           in: query
-          description: Return the percent change in the values. Currently we support change over 24hour, 7 Days and 30 Days.
+          description: Return the percent change in the values. Currently we support change over 24hour, 7 Days and 30 Days. It is false by default.
           required: false
           schema:
             type: boolean


### PR DESCRIPTION
Market Cap API supports returning the values as well as the change in values over 24h, 7d, 30d period.

We have introduced a flag which will toggle wether the percent change is returned. By default the percent change will not be returned as part of the response.