### PR TITLE
Index Type parameter is required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -218,7 +218,7 @@ components:
           format: uuid
         indexType:
           description: The index type of thhe OHLCV
-          required: false
+          required: true
           type: string
           enum:
             - MWA
@@ -1147,7 +1147,7 @@ paths:
         - name: indexType
           in: query
           description: Retrieve the index by the type.
-          required: false
+          required: true
           schema:
             type: string
             enum:


### PR DESCRIPTION
The indexType query parameter is a required field for Index Tickers and OHLCV